### PR TITLE
AutoAWQ: initial support

### DIFF
--- a/models/config.yaml
+++ b/models/config.yaml
@@ -174,3 +174,5 @@
   instruction_template: 'Llama-v2'
 .*mistral.*instruct:
   instruction_template: 'Mistral'
+.*AWQ:
+  n_batch: 1

--- a/modules/loaders.py
+++ b/modules/loaders.py
@@ -129,6 +129,13 @@ loaders_and_params = OrderedDict({
         'model_type',
         'no_mmap',
         'mlock'
+    ],
+    'AutoAWQ': [
+        'max_seq_len',
+        'n_batch',
+        'no_inject_fused_attention',
+        'trust_remote_code',
+        'use_fast',
     ]
 })
 
@@ -353,7 +360,38 @@ loaders_samplers = {
         'top_k',
         'repetition_penalty',
         'repetition_penalty_range',
-    }
+    },
+    'AutoAWQ': {
+        'temperature',
+        'top_p',
+        'top_k',
+        'typical_p',
+        'epsilon_cutoff',
+        'eta_cutoff',
+        'tfs',
+        'top_a',
+        'repetition_penalty',
+        'repetition_penalty_range',
+        'encoder_repetition_penalty',
+        'no_repeat_ngram_size',
+        'min_length',
+        'seed',
+        'do_sample',
+        'penalty_alpha',
+        'num_beams',
+        'length_penalty',
+        'early_stopping',
+        'mirostat_mode',
+        'mirostat_tau',
+        'mirostat_eta',
+        'guidance_scale',
+        'negative_prompt',
+        'ban_eos_token',
+        'custom_token_bans',
+        'add_bos_token',
+        'skip_special_tokens',
+        'auto_max_new_tokens',
+    },
 }
 
 loaders_model_types = {

--- a/modules/models.py
+++ b/modules/models.py
@@ -63,6 +63,7 @@ def load_model(model_name, loader=None):
         'ExLlamav2': ExLlamav2_loader,
         'ExLlamav2_HF': ExLlamav2_HF_loader,
         'ctransformers': ctransformers_loader,
+        'AutoAWQ': AutoAWQ_loader,
     }
 
     if loader is None:
@@ -276,6 +277,23 @@ def ctransformers_loader(model_name):
     model, tokenizer = ctrans.from_pretrained(model_file)
     return model, tokenizer
 
+def AutoAWQ_loader(model_name):
+   from awq import AutoAWQForCausalLM
+
+   model_dir = Path(f'{shared.args.model_dir}/{model_name}')
+
+   if shared.args.deepspeed:
+       logger.warn("AutoAWQ is incompatible with deepspeed")
+
+   model = AutoAWQForCausalLM.from_quantized(
+       quant_path=model_dir,
+       max_new_tokens=shared.args.max_seq_len,
+       trust_remote_code=shared.args.trust_remote_code,
+       fuse_layers=not shared.args.no_inject_fused_attention,
+       batch_size=shared.args.n_batch,
+       safetensors=not shared.args.trust_remote_code)
+
+   return model
 
 def GPTQ_loader(model_name):
 

--- a/modules/models_settings.py
+++ b/modules/models_settings.py
@@ -111,6 +111,8 @@ def infer_loader(model_name, model_settings):
         loader = 'llama.cpp'
     elif re.match(r'.*\.gguf', model_name.lower()):
         loader = 'llama.cpp'
+    elif re.match(r'.*-awq', model_name.lower()):
+        loader = 'AutoAWQ'
     elif re.match(r'.*rwkv.*\.pth', model_name.lower()):
         loader = 'RWKV'
     elif re.match(r'.*exl2', model_name.lower()):

--- a/modules/ui_model_menu.py
+++ b/modules/ui_model_menu.py
@@ -99,7 +99,7 @@ def create_ui():
 
                         with gr.Column():
                             shared.gradio['triton'] = gr.Checkbox(label="triton", value=shared.args.triton)
-                            shared.gradio['no_inject_fused_attention'] = gr.Checkbox(label="no_inject_fused_attention", value=shared.args.no_inject_fused_attention, info='Disable fused attention. Fused attention improves inference performance but uses more VRAM. Disable if running low on VRAM.')
+                            shared.gradio['no_inject_fused_attention'] = gr.Checkbox(label="no_inject_fused_attention", value=shared.args.no_inject_fused_attention, info='Disable fused attention. Fused attention improves inference performance but uses more VRAM. Fuses layers for AutoAWQ. Disable if running low on VRAM.')
                             shared.gradio['no_inject_fused_mlp'] = gr.Checkbox(label="no_inject_fused_mlp", value=shared.args.no_inject_fused_mlp, info='Affects Triton only. Disable fused MLP. Fused MLP improves performance but uses more VRAM. Disable if running low on VRAM.')
                             shared.gradio['no_use_cuda_fp16'] = gr.Checkbox(label="no_use_cuda_fp16", value=shared.args.no_use_cuda_fp16, info='This can make models faster on some systems.')
                             shared.gradio['desc_act'] = gr.Checkbox(label="desc_act", value=shared.args.desc_act, info='\'desc_act\', \'wbits\', and \'groupsize\' are used for old models without a quantize_config.json.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,6 @@ https://github.com/jllllll/llama-cpp-python-cuBLAS-wheels/releases/download/text
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.0/gptq_for_llama-0.1.0+cu117-cp310-cp310-win_amd64.whl; platform_system == "Windows"
 https://github.com/jllllll/GPTQ-for-LLaMa-CUDA/releases/download/0.1.0/gptq_for_llama-0.1.0+cu117-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64"
 https://github.com/jllllll/ctransformers-cuBLAS-wheels/releases/download/AVX2/ctransformers-0.2.27+cu117-py3-none-any.whl
+
+# autoawq
+autoawq==0.1.2


### PR DESCRIPTION
 Tested with:
 * https://huggingface.co/TheBloke/vicuna-13B-v1.5-16K-AWQ
 * https://huggingface.co/TheBloke/wizard-vicuna-13B-AWQ

Known issues:
 * Seems to be incompatible with DeepSpeed, working when disabled:
```
text-generation-webui  |   File "/venv/lib/python3.10/site-packages/deepspeed/runtime/zero/partition_parameters.py", line 984, in _post_init_method
text-generation-webui  |     param.data = param.data.to(self.local_device)
text-generation-webui  | NotImplementedError: Cannot copy out of meta tensor; no data!
```

## Checklist:

- [ ] I have read the [Contributing guidelines](https://github.com/oobabooga/text-generation-webui/wiki/Contributing-guidelines).
